### PR TITLE
[RS-257] Bug: Reduce Function Without Initial Value

### DIFF
--- a/src/api/solutions.ts
+++ b/src/api/solutions.ts
@@ -71,7 +71,7 @@ export default {
       })),
       globals_values: Object.keys(globals)
         .map((globalName) => ({ [globalName]: globals[globalName].value }))
-        .reduce((previous, current) => ({ ...previous, ...current })),
+        .reduce((previous, current) => ({ ...previous, ...current }), {}),
     });
   },
 
@@ -100,7 +100,7 @@ export default {
       })),
       globals_values: Object.keys(globals)
         .map((globalName) => ({ [globalName]: globals[globalName].value }))
-        .reduce((previous, current) => ({ ...previous, ...current })),
+        .reduce((previous, current) => ({ ...previous, ...current }), {}),
     });
   },
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the globals object is empty, it emits an error, because it is not possible to execute the reduce function on an empty array without defining an initial value for the reduce.

### Summary of Changes
<!--- Describe your changes in detail -->
* Adds initial value for the reduce.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/88ed0eec-a921-4c51-a6d8-684cadfbc37d)
