### PR TITLE
[CFE-615] - Fix Module Federation translations

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -107,8 +107,8 @@ export default defineConfig({
     }),
     new VueLoaderPlugin(),
     new rspack.container.ModuleFederationPlugin({
-      name: 'remote',
-      filename: 'remote.js',
+      name: 'commerce',
+      filename: 'remoteEntry.js',
       exposes: {
         './solution-card': './src/views/Discovery.vue',
         './locales/pt_br': './src/locales/pt-BR.json',
@@ -116,7 +116,7 @@ export default defineConfig({
         './locales/es_es': './src/locales/es-ES.json',
       },
       remotes: {
-        host: `host@${process.env.MODULE_FEDERATION_CONNECT_URL}/remoteEntry.js`,
+        connect: `connect@${process.env.MODULE_FEDERATION_CONNECT_URL}/remoteEntry.js`,
       },
       shared: {
         ...pkg,

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -111,6 +111,9 @@ export default defineConfig({
       filename: 'remote.js',
       exposes: {
         './solution-card': './src/views/Discovery.vue',
+        './locales/pt_br': './src/locales/pt-BR.json',
+        './locales/en_us': './src/locales/en-US.json',
+        './locales/es_es': './src/locales/es-ES.json',
       },
       remotes: {
         host: `host@${process.env.MODULE_FEDERATION_CONNECT_URL}/remoteEntry.js`,

--- a/src/views/Discovery.vue
+++ b/src/views/Discovery.vue
@@ -1,8 +1,6 @@
 <template>
   <SolutionsList
-    v-if="
-      ['default', 'remote'].includes(type)
-    "
+    v-if="['default', 'remote'].includes(type)"
     show="available"
     :isFirstLoading="isFirstLoading"
     :activeNotifications="solutionsActiveStore"
@@ -40,10 +38,9 @@ const isFirstLoading = computed(() => {
   return props.type === 'default' ? loadingDefault : loadingRemote;
 });
 
-
 onMounted(() => {
   if (props.type === 'remote') {
-    import('host/sharedStore').then(({ useSharedStore }) => {
+    import('connect/sharedStore').then(({ useSharedStore }) => {
       const sharedStore = useSharedStore();
       const authStore = useAuthStore();
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
To solve the technical debt of synchronizing translations between Module Federation modules

### Summary of Changes
- Renamed the Module Federation filename to follow the `remoteEntry` pattern;
- Renamed the module name in Module Federation settings and renamed the hostname to `connect`;
- Added export of translation files to Module Federation.
